### PR TITLE
Config yudien through structs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,6 +15,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/ghowland/ddd"
+  packages = ["ddd"]
+  revision = "2eafe38a30c2f610f83d8e8f47f512f48c46547b"
+
+[[projects]]
+  branch = "master"
   name = "github.com/jacksontj/dataman"
   packages = ["src/datamantype","src/httputil","src/query","src/router_node/functiondefault","src/router_node/sharding","src/storage_node","src/storage_node/datasource","src/storage_node/datasource/pgstore","src/storage_node/metadata","src/storage_node/metadata/filter"]
   revision = "de2b7a0179d3b93d6d01191e80fed6ec531683a5"
@@ -74,6 +80,18 @@
   revision = "ebfc5b4631820b793c9010c87fd8fef0f39eb082"
 
 [[projects]]
+  name = "gopkg.in/asn1-ber.v1"
+  packages = ["."]
+  revision = "379148ca0225df7a432012b8df0355c2a2063ac0"
+  version = "v1.2"
+
+[[projects]]
+  name = "gopkg.in/ldap.v2"
+  packages = ["."]
+  revision = "8168ee085ee43257585e50c6441aadf54ecb2c9f"
+  version = "v2.5.0"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -82,6 +100,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "728fdf17933ba4e0604bbfc69fb1e2239adee961217b5ef3c9fb851bee6049fd"
+  inputs-digest = "b3e15ee4330793add3675ad5bf7f78a84d64fc33ac14c8bbe9f0145b9aea89f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/yudien/ldap.go
+++ b/yudien/ldap.go
@@ -2,11 +2,9 @@ package yudien
 
 import (
 	"fmt"
-	. "github.com/ghowland/yudien/yudienutil"
-	"gopkg.in/ldap.v2"
-	"os/user"
 	"strconv"
-	"strings"
+
+	"gopkg.in/ldap.v2"
 )
 
 type LdapUser struct {
@@ -29,17 +27,10 @@ func LdapLogin(username string, password string) LdapUser {
 	ldap_user := LdapUser{}
 	ldap_user.Username = username
 
-	// Get all LDAP auth from config file...  JSON is fine...
+	ldapHost := fmt.Sprintf("%s:%d", Ldap.Host, Ldap.Port)
+	fmt.Printf("LDAP: %s\n", ldapHost)
 
-	usr, _ := user.Current()
-	homedir := usr.HomeDir
-
-	server_port := ReadPathData(fmt.Sprintf("%s/secure/ldap_connect_port.txt", homedir)) // Should contain contents, no newlines: host.domain.com:389
-	server_port = strings.Trim(server_port, " \n")
-
-	fmt.Printf("LDAP: %s\n", server_port)
-
-	l, err := ldap.Dial("tcp", server_port)
+	l, err := ldap.Dial("tcp", ldapHost)
 	if err != nil {
 		ldap_user.IsAuthenticated = false
 		ldap_user.Error = err.Error()
@@ -49,16 +40,10 @@ func LdapLogin(username string, password string) LdapUser {
 
 	fmt.Printf("Dial complete\n")
 
-	ldap_password := ReadPathData(fmt.Sprintf("%s/secure/notcleartextpasswords.txt", homedir)) // Should contain exact password, no newlines.
-	ldap_password = strings.Trim(ldap_password, " \n")
-
-	sbr := ldap.SimpleBindRequest{}
-
-	ldap_userconnect := ReadPathData(fmt.Sprintf("%s/secure/ldap_userconnectstring.txt", homedir)) // Should contain connection string, no newlines: "dc=example,dc=com"
-	ldap_userconnect = strings.Trim(ldap_userconnect, " \n")
-
-	sbr.Username = ldap_userconnect
-	sbr.Password = ldap_password
+	sbr := ldap.SimpleBindRequest{
+		Username: Ldap.LoginDN,
+		Password: Ldap.Password,
+	}
 	_, err = l.SimpleBind(&sbr)
 	if err != nil {
 		ldap_user.IsAuthenticated = false
@@ -76,11 +61,7 @@ func LdapLogin(username string, password string) LdapUser {
 	//TODO(g): Get these from JSON or something?  Not sure...  Probably JSON.  This is all ghetto, but it keeps things mostly anonymous and flexible
 	attributes := []string{"cn", "gidNumber", "givenName", "homeDirectory", "loginShell", "mail", "sn", "uid", "uidNumber", "userPassword"}
 
-	ldap_usersearch := ReadPathData(fmt.Sprintf("%s/secure/ldap_usersearch.txt", homedir)) // Should contain connection string, no newlines: "dc=example,dc=com"
-	ldap_usersearch = strings.Trim(ldap_usersearch, " \n")
-
-	sr := ldap.NewSearchRequest(ldap_usersearch, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false, filter, attributes, nil)
-
+	sr := ldap.NewSearchRequest(Ldap.UserSearch, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false, filter, attributes, nil)
 	user_result, err := l.Search(sr)
 	if err != nil {
 		ldap_user.IsAuthenticated = false
@@ -116,11 +97,7 @@ func LdapLogin(username string, password string) LdapUser {
 	//TODO(g): Get these from JSON or something?  Not sure...  Probably JSON.  This is all ghetto, but it keeps things mostly anonymous and flexible
 	attributes = []string{"cn", "gidNumber", "memberUid"}
 
-	ldap_groupsearch := ReadPathData(fmt.Sprintf("%s/secure/ldap_groupsearch.txt", homedir)) // Should contain connection string, no newlines: "ou=groups,dc=example,dc=com"
-	ldap_groupsearch = strings.Trim(ldap_groupsearch, " \n")
-
-	sr = ldap.NewSearchRequest(ldap_groupsearch, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false, filter, attributes, nil)
-
+	sr = ldap.NewSearchRequest(Ldap.GroupSearch, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false, filter, attributes, nil)
 	group_result, err := l.Search(sr)
 	if err != nil {
 		ldap_user.IsAuthenticated = false
@@ -149,7 +126,7 @@ func LdapLogin(username string, password string) LdapUser {
 	fmt.Printf("User: %s  Groups: %v\n", username, user_groups)
 
 	// Testing password
-	err = l.Bind(fmt.Sprintf("uid=%s,%s", username, ldap_usersearch), password)
+	err = l.Bind(fmt.Sprintf("uid=%s,%s", username, Ldap.UserSearch), password)
 	if err != nil {
 		ldap_user.IsAuthenticated = false
 		ldap_user.Error = err.Error()

--- a/yudiendata/data.go
+++ b/yudiendata/data.go
@@ -5,15 +5,16 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
+
 	. "github.com/ghowland/yudien/yudienutil"
 	"github.com/jacksontj/dataman/src/query"
 	"github.com/jacksontj/dataman/src/storage_node"
 	"github.com/jacksontj/dataman/src/storage_node/metadata"
 	"github.com/junhsieh/goexamples/fieldbinding/fieldbinding"
-	"io/ioutil"
-	"log"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -37,8 +38,6 @@ const (
 )
 
 var DatasourceInstance = map[string]*storagenode.DatasourceInstance{}
-
-var PgConnect string
 
 func GetSelectedDb(db_web *sql.DB, db *sql.DB, db_id int64) *sql.DB {
 	// Assume we are using the non-web DB
@@ -271,11 +270,11 @@ func SanitizeSQL(text string) string {
 	return text
 }
 
-func InitDataman() {
+func InitDataman(pgconnect string) {
 	config := storagenode.DatasourceInstanceConfig{
 		StorageNodeType: "postgres",
 		StorageConfig: map[string]interface{}{
-			"pg_string": PgConnect,
+			"pg_string": pgconnect,
 		},
 	}
 
@@ -297,12 +296,4 @@ func InitDataman() {
 	} else {
 		panic(err)
 	}
-}
-
-func init() {
-	PgConnect = ReadPathData("data/opsdb.connect")
-
-	// Initialize Dataman
-	InitDataman()
-
 }


### PR DESCRIPTION
Split up udn initialization and ldap/db configuration steps so
configuration can be controlled by applications built on top
of yudien. Apps must now call yudien.Configure with the
db/ldap configurations.