### PR TITLE
Temp Variable Fix & Get/Set Array Indexing

### DIFF
--- a/yudien/core_functions.go
+++ b/yudien/core_functions.go
@@ -1304,38 +1304,6 @@ func UDN_JsonEncode(db *sql.DB, udn_schema map[string]interface{}, udn_start *Ud
 	return result
 }
 
-func UDN_GetIndex(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
-	UdnLog(udn_schema, "Get Index: %v\n", args)
-
-	result := UdnResult{}
-
-	index := GetResult(args[0], type_string).(string)
-
-	actual_input := input
-	if len(args) > 1 {
-		actual_input = args[1]
-	}
-
-	switch actual_input.(type) {
-	case []string:
-		index_int := GetResult(index, type_int).(int64)
-		result.Result = actual_input.([]string)[index_int]
-	case []interface{}:
-		index_int := GetResult(index, type_int).(int64)
-		result.Result = actual_input.([]interface{})[index_int]
-	case []map[string]interface{}:
-		index_int := GetResult(index, type_int).(int64)
-		result.Result = actual_input.([]map[string]interface{})[index_int]
-	case map[string]interface{}:
-		result.Result = actual_input.(map[string]interface{})[index]
-	default:
-		result.Result = actual_input
-	}
-
-
-	return result
-}
-
 func UDN_DataGet(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
 	UdnLog(udn_schema, "Data Get: %v\n", args)
 

--- a/yudien/internals.go
+++ b/yudien/internals.go
@@ -103,13 +103,27 @@ func GetChildResult(parent interface{}, child interface{}) DynamicResult {
 
 	result := DynamicResult{}
 
+	// Check if the parent is an array or a map
 	if strings.HasPrefix(type_str, "[]") {
-		// Array access
-		parent_array := parent.([]interface{})
+		// Array access - check what type of array the parent is
+		switch parent.(type) {
+		case []string:
+			parent_array := parent.([]string)
+			index := GetResult(child, type_int).(int64)
+			result.Result = parent_array[index]
+		case []interface{}:
+			parent_array := parent.([]interface{})
+			index := GetResult(child, type_int).(int64)
+			result.Result = parent_array[index]
+		case []map[string]interface{}:
+			parent_array := parent.([]map[string]interface{})
+			index := GetResult(child, type_int).(int64)
+			result.Result = parent_array[index]
+		default:
+			// Array type not recognized - return parent for now
+			result.Result = parent
+		}
 
-		index := GetResult(child, type_int).(int64)
-
-		result.Result = parent_array[index]
 		result.Type = type_array
 
 		return result
@@ -169,13 +183,26 @@ func SetChildResult(parent interface{}, child interface{}, value interface{}) {
 	type_str := fmt.Sprintf("%T", parent)
 	//fmt.Printf("\n\nSetChildResult: %s: %v: %v\n\n", type_str, child, SnippetData(parent, 300))
 
+	// Check if the parent is an array or a map
 	if strings.HasPrefix(type_str, "[]") {
-		// Array access
-		parent_array := parent.([]interface{})
+		// Array access - check what type of array the parent is
+		switch parent.(type) {
+		case []string:
+			parent_array := parent.([]string)
+			index := GetResult(child, type_int).(int64)
+			parent_array[index] = value.(string)
+		case []interface{}:
+			parent_array := parent.([]interface{})
+			index := GetResult(child, type_int).(int64)
+			parent_array[index] = value
+		case []map[string]interface{}:
+			parent_array := parent.([]map[string]interface{})
+			index := GetResult(child, type_int).(int64)
+			parent_array[index] = value.(map[string]interface{})
+		default:
+			// type is not recognized - do nothing for now
+		}
 
-		index := GetResult(child, type_int).(int64)
-
-		parent_array[index] = value
 	} else {
 		child_str := GetResult(child, type_string).(string)
 

--- a/yudien/yudien.go
+++ b/yudien/yudien.go
@@ -284,12 +284,14 @@ func ProcessSchemaUDNSet(db *sql.DB, udn_schema map[string]interface{}, udn_data
 			}
 		}
 
-		// Remove the latest function stack, that we just put on
-		udn_data["__function_stack"] = udn_data["__function_stack"].([]map[string]interface{})[0:len(udn_data["__function_stack"].([]map[string]interface{}))]
+		// Remove the udn_data["__temp_UUID"] data, so it doesn't just pollute the udn_data space
+		if udn_data["__temp"] != nil {
+			delete(udn_data["__temp"].(map[string]interface{}), new_function_stack["uuid"].(string))
+		}
 
-		//TODO(g): Remove the udn_data["__temp_UUID"] data, so it doesnt just polluate up the udn_data space?  Once we have returned, we dont need it anymore...
-		//CleanUdnTempSpace(new_function_stack["uuid"])
-		//
+		// Remove the latest function stack, that we just put on
+		udn_data["__function_stack"] = udn_data["__function_stack"].([]map[string]interface{})[0:len(udn_data["__function_stack"].([]map[string]interface{}))-1]
+
 	} else {
 		fmt.Print("UDN Execution Group: None\n\n")
 	}


### PR DESCRIPTION
- Fixed stack bug with __get_temp/__set_temp - temp variables are now local in scope to the function
- Extended array indexing ability for __get/__set/__get_temp/__set_temp - these functions will work on maps & arrays (of several array types)
- Removed UDN_GetIndex as __get/__get_temp now performs the same function with depth searching