### PR TITLE
Bug Fix + __set_index/__get_index

### DIFF
--- a/yudien/core_functions.go
+++ b/yudien/core_functions.go
@@ -1304,38 +1304,6 @@ func UDN_JsonEncode(db *sql.DB, udn_schema map[string]interface{}, udn_start *Ud
 	return result
 }
 
-func UDN_GetIndex(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
-	UdnLog(udn_schema, "Get Index: %v\n", args)
-
-	result := UdnResult{}
-
-	index := GetResult(args[0], type_string).(string)
-
-	actual_input := input
-	if len(args) > 1 {
-		actual_input = args[1]
-	}
-
-	switch actual_input.(type) {
-	case []string:
-		index_int := GetResult(index, type_int).(int64)
-		result.Result = actual_input.([]string)[index_int]
-	case []interface{}:
-		index_int := GetResult(index, type_int).(int64)
-		result.Result = actual_input.([]interface{})[index_int]
-	case []map[string]interface{}:
-		index_int := GetResult(index, type_int).(int64)
-		result.Result = actual_input.([]map[string]interface{})[index_int]
-	case map[string]interface{}:
-		result.Result = actual_input.(map[string]interface{})[index]
-	default:
-		result.Result = actual_input
-	}
-
-
-	return result
-}
-
 func UDN_DataGet(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
 	UdnLog(udn_schema, "Data Get: %v\n", args)
 

--- a/yudien/core_functions.go
+++ b/yudien/core_functions.go
@@ -1520,13 +1520,12 @@ func UDN_GetFirst(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnP
 }
 
 func UDN_Get(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
-	UdnLog(udn_schema, "Get: %v\n", SnippetData(args, 80))
+	//UdnLog(udn_schema, "Get: %v\n", SnippetData(args, 80))
 
 	result := UdnResult{}
 	result.Result = MapGet(args, udn_data)
 
-	UdnLog(udn_schema, "Get: %v   Result: %v\n", SnippetData(args, 80), SnippetData(result.Result, 80))
-	//UdnLog(udn_schema, "Get: %v   Result: %v\n", SnippetData(args, 80), result.Result)
+	//UdnLog(udn_schema, "Get: %v   Result: %v\n", SnippetData(args, 80), SnippetData(result.Result, 80))
 
 	return result
 }
@@ -1536,6 +1535,43 @@ func UDN_Set(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, 
 
 	result := UdnResult{}
 	result.Result = MapSet(args, input, udn_data)
+
+	//UdnLog(udn_schema, "Set: %v  Result: %s\n\n", SnippetData(args, 80), SnippetData(result.Result, 80))
+
+	return result
+}
+
+func UDN_GetIndex(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
+	//UdnLog(udn_schema, "Get Index: %v\n", SnippetData(args, 80))
+
+	result := UdnResult{}
+
+	if len(args) > 0 {
+		result.Result = MapGet(args, input)
+	} else {
+		result.Result = input
+	}
+
+	//UdnLog(udn_schema, "Get Index: %v   Result: %v\n", SnippetData(args, 80), SnippetData(result.Result, 80))
+
+	return result
+}
+
+func UDN_SetIndex(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
+	//UdnLog(udn_schema, "Set: %v   Input: %s\n", SnippetData(args, 80), SnippetData(input, 40))
+
+	result := UdnResult{}
+
+	args_len := len(args)
+
+	if args_len >= 2 {
+		// args[args_len - 1] is the new value to update the input while args[0:args_len - 1] represent the target path
+		result.Result = MapIndexSet(args[0:args_len - 1], args[args_len - 1], input)
+	} else if args_len == 1 { // Return the only argument
+		result.Result = args[0]
+	} else { // Pass through input if no args passed
+		result.Result = input
+	}
 
 	//UdnLog(udn_schema, "Set: %v  Result: %s\n\n", SnippetData(args, 80), SnippetData(result.Result, 80))
 

--- a/yudien/core_functions.go
+++ b/yudien/core_functions.go
@@ -1084,6 +1084,96 @@ func UDN_Execute(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPa
 	return result
 }
 
+func UDN_ArraySlice(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
+	// UdnLog(udn_schema, "Slice: %v\n", SnippetData(args, 80))
+
+	result := UdnResult{}
+
+	start_index := 0
+	end_index := 0
+	args_len := len(args)
+	input_len := 0
+
+	// Find len of input array
+	switch input.(type){
+	case []interface{}:
+		input_len = len(input.([]interface{}))
+	case []map[string]interface{}:
+		input_len = len(input.([]map[string]interface{}))
+	default: // Cannot recognize input array type. Return input
+		result.Result = input
+		return result
+	}
+
+	// Check that start and end indices are present & given in int format
+	if args_len == 0 { // No index given, return input
+		result.Result = input
+		return result
+	} else if args_len == 1 { // Only start index given. Assume end_index is at end of array
+		start_int, err := strconv.Atoi(args[0].(string))
+
+		if err == nil{
+			start_index = start_int
+			end_index = input_len
+		} else {
+			result.Result = input
+			return result
+		}
+	} else { // Both start and end indices are given
+		start_int, err1 := strconv.Atoi(args[0].(string))
+		end_int, err2 := strconv.Atoi(args[1].(string))
+
+		if err1 == nil && err2 == nil {
+			start_index = start_int
+			end_index = end_int
+		} else {
+			result.Result = input
+			return result
+		}
+	}
+
+	// Make sure that the start & end index are correct - Order of these error checks matter
+	// Implement negative indexing (not default in Go)
+	if start_index < 0 {
+		start_index = input_len + start_index + 1 // -1 is the last element (start at -1 and not -0)
+	}
+	if end_index < 0 {
+		end_index = input_len + end_index + 1
+	}
+
+	// Check for out of bounds - force the index to be in range
+	if start_index > input_len {
+		start_index = input_len
+	}
+	if start_index < 0 { // If start_index is still < 0 after negative adjustment, then it is out of bounds
+		start_index = 0
+	}
+	if end_index > input_len {
+		end_index = input_len
+	}
+	if end_index < 0 {
+		end_index = 0
+	}
+
+	// Check that end index is not before start index (index error)
+	if end_index < start_index { // Return empty array
+		start_index = 0
+		end_index = 0
+	}
+
+	// Finally, return the slice of array
+	switch input.(type){
+	case []interface{}:
+		result.Result = input.([]interface{})[start_index:end_index]
+	case []map[string]interface{}:
+		result.Result = input.([]map[string]interface{})[start_index:end_index]
+	default: // Cannot recognize input array type. Return input
+		result.Result = input
+	}
+
+	return result
+}
+
 func UDN_ArrayAppend(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, args []interface{}, input interface{}, udn_data map[string]interface{}) UdnResult {
 	//UdnLog(udn_schema, "Array Append: %v\n", args)
 

--- a/yudien/core_functions.go
+++ b/yudien/core_functions.go
@@ -1096,6 +1096,8 @@ func UDN_ArraySlice(db *sql.DB, udn_schema map[string]interface{}, udn_start *Ud
 
 	// Find len of input array
 	switch input.(type){
+	case []string:
+		input_len = len(input.([]string))
 	case []interface{}:
 		input_len = len(input.([]interface{}))
 	case []map[string]interface{}:
@@ -1163,6 +1165,8 @@ func UDN_ArraySlice(db *sql.DB, udn_schema map[string]interface{}, udn_start *Ud
 
 	// Finally, return the slice of array
 	switch input.(type){
+	case []string:
+		result.Result = input.([]string)[start_index:end_index]
 	case []interface{}:
 		result.Result = input.([]interface{})[start_index:end_index]
 	case []map[string]interface{}:

--- a/yudien/internals.go
+++ b/yudien/internals.go
@@ -103,13 +103,27 @@ func GetChildResult(parent interface{}, child interface{}) DynamicResult {
 
 	result := DynamicResult{}
 
+	// Check if the parent is an array or a map
 	if strings.HasPrefix(type_str, "[]") {
-		// Array access
-		parent_array := parent.([]interface{})
+		// Array access - check what type of array the parent is
+		switch parent.(type) {
+		case []string:
+			parent_array := parent.([]string)
+			index := GetResult(child, type_int).(int64)
+			result.Result = parent_array[index]
+		case []interface{}:
+			parent_array := parent.([]interface{})
+			index := GetResult(child, type_int).(int64)
+			result.Result = parent_array[index]
+		case []map[string]interface{}:
+			parent_array := parent.([]map[string]interface{})
+			index := GetResult(child, type_int).(int64)
+			result.Result = parent_array[index]
+		default:
+			// Array type not recognized - return parent for now
+			result.Result = parent
+		}
 
-		index := GetResult(child, type_int).(int64)
-
-		result.Result = parent_array[index]
 		result.Type = type_array
 
 		return result
@@ -169,13 +183,26 @@ func SetChildResult(parent interface{}, child interface{}, value interface{}) {
 	type_str := fmt.Sprintf("%T", parent)
 	//fmt.Printf("\n\nSetChildResult: %s: %v: %v\n\n", type_str, child, SnippetData(parent, 300))
 
+	// Check if the parent is an array or a map
 	if strings.HasPrefix(type_str, "[]") {
-		// Array access
-		parent_array := parent.([]interface{})
+		// Array access - check what type of array the parent is
+		switch parent.(type) {
+		case []string:
+			parent_array := parent.([]string)
+			index := GetResult(child, type_int).(int64)
+			parent_array[index] = value.(string)
+		case []interface{}:
+			parent_array := parent.([]interface{})
+			index := GetResult(child, type_int).(int64)
+			parent_array[index] = value
+		case []map[string]interface{}:
+			parent_array := parent.([]map[string]interface{})
+			index := GetResult(child, type_int).(int64)
+			parent_array[index] = value.(map[string]interface{})
+		default:
+			// type is not recognized - do nothing for now
+		}
 
-		index := GetResult(child, type_int).(int64)
-
-		parent_array[index] = value
 	} else {
 		child_str := GetResult(child, type_string).(string)
 

--- a/yudien/internals.go
+++ b/yudien/internals.go
@@ -141,7 +141,7 @@ func GetChildResult(parent interface{}, child interface{}) DynamicResult {
 	}
 }
 
-func _MapGet(args []interface{}, udn_data map[string]interface{}) interface{} {
+func _MapGet(args []interface{}, udn_data interface{}) interface{} {
 	// This is what we will use to Set the data into the last map[string]
 	last_argument := GetResult(args[len(args)-1], type_string).(string)
 
@@ -214,7 +214,7 @@ func SetChildResult(parent interface{}, child interface{}, value interface{}) {
 	}
 }
 
-func _MapSet(args []interface{}, input interface{}, udn_data map[string]interface{}) {
+func _MapSet(args []interface{}, input interface{}, udn_data interface{}) {
 
 	// This is what we will use to Set the data into the last map[string]
 	last_argument := GetResult(args[len(args)-1], type_string).(string)
@@ -246,7 +246,7 @@ func _MapSet(args []interface{}, input interface{}, udn_data map[string]interfac
 	SetChildResult(cur_udn_data, last_argument, input)
 }
 
-func MapGet(args []interface{}, udn_data map[string]interface{}) interface{} {
+func MapGet(args []interface{}, udn_data interface{}) interface{} {
 	// If we were given a single dotted string, expand it into our arg array
 	args = UseArgArrayOrFirstArgString(args)
 
@@ -263,12 +263,12 @@ func MapGet(args []interface{}, udn_data map[string]interface{}) interface{} {
 	return result
 }
 
-func MapSet(args []interface{}, input interface{}, udn_data map[string]interface{}) interface{} {
+func MapSet(args []interface{}, input interface{}, udn_data interface{}) interface{} {
 	// Determine what our args should be, based on whether the data is available for getting already, allow explicit to override depth-search
 	first_args := UseArgArrayOrFirstArgString(args)
 	result := _MapGet(first_args, udn_data)
 	if result == nil {
-		// If we didnt find this value in it's explicit (dotted) string location, then expand the dots
+		// If we didn't find this value in it's explicit (dotted) string location, then expand the dots
 		args = GetArgsFromArgsOrStrings(args)
 	} else {
 		args = first_args
@@ -278,6 +278,25 @@ func MapSet(args []interface{}, input interface{}, udn_data map[string]interface
 
 	// Input is a pass-through
 	return input
+}
+
+func MapIndexSet(args []interface{}, input interface{}, udn_data interface{}) interface{} {
+	// Same as func MapSet but udn_data is returned rather than input
+
+	// Determine what our args should be, based on whether the data is available for getting already, allow explicit to override depth-search
+	first_args := UseArgArrayOrFirstArgString(args)
+	result := _MapGet(first_args, udn_data)
+	if result == nil {
+		// If we didn't find this value in it's explicit (dotted) string location, then expand the dots
+		args = GetArgsFromArgsOrStrings(args)
+	} else {
+		args = first_args
+	}
+
+	_MapSet(args, input, udn_data)
+
+	// Return the updated udn_data
+	return udn_data
 }
 
 // Parse a UDN string and return a hierarchy under UdnPart

--- a/yudien/yudien.go
+++ b/yudien/yudien.go
@@ -284,12 +284,14 @@ func ProcessSchemaUDNSet(db *sql.DB, udn_schema map[string]interface{}, udn_data
 			}
 		}
 
-		// Remove the latest function stack, that we just put on
-		udn_data["__function_stack"] = udn_data["__function_stack"].([]map[string]interface{})[0:len(udn_data["__function_stack"].([]map[string]interface{}))]
+		// Remove the udn_data["__temp_UUID"] data, so it doesn't just pollute the udn_data space
+		if udn_data["__temp"] != nil {
+			delete(udn_data["__temp"].(map[string]interface{}), new_function_stack["uuid"].(string))
+		}
 
-		//TODO(g): Remove the udn_data["__temp_UUID"] data, so it doesnt just polluate up the udn_data space?  Once we have returned, we dont need it anymore...
-		//CleanUdnTempSpace(new_function_stack["uuid"])
-		//
+		// Remove the latest function stack, that we just put on
+		udn_data["__function_stack"] = udn_data["__function_stack"].([]map[string]interface{})[0:len(udn_data["__function_stack"].([]map[string]interface{}))-1]
+
 	} else {
 		fmt.Print("UDN Execution Group: None\n\n")
 	}

--- a/yudien/yudien.go
+++ b/yudien/yudien.go
@@ -118,6 +118,8 @@ func InitUdn() {
 		"__end_iterate":  nil,
 		"__get":          UDN_Get,
 		"__set":          UDN_Set,
+		"__get_index": 	  UDN_GetIndex, // Get data using input rather than args (otherwise same as __get)
+		"__set_index": 	  UDN_SetIndex, // Set data like __set but does not the result is passed to output and not stored
 		"__get_first":    UDN_GetFirst, // Takes N strings, which are dotted for udn_data accessing.  The first value that isnt nil is returned.  nil is returned if they all are
 		"__get_temp":     UDN_GetTemp,  // Function stack based temp storage
 		"__set_temp":     UDN_SetTemp,  // Function stack based temp storage
@@ -181,7 +183,6 @@ func InitUdn() {
 		"__split":     UDN_StringSplit, // Split a string
 		"__lower":     UDN_StringLower, // Lower case a string
 		"__upper":     UDN_StringUpper, // Upper case a string
-		"__get_index": UDN_GetIndex,    // Get data from an index
 
 		//TODO(g): I think I dont need this, as I can pass it to __ddd_render directly
 		//"__ddd_move": UDN_DddMove,				// DDD Move position.current.x.y:  Takes X/Y args, attempted to move:  0.1.1 ^ 0.1.0 < 0.1 > 0.1.0 V 0.1.1

--- a/yudien/yudien.go
+++ b/yudien/yudien.go
@@ -156,6 +156,7 @@ func InitUdn() {
 
 		"__array_append": UDN_ArrayAppend, // Appends the input into the specified target location (args)
 
+		"__array_slice": UDN_ArraySlice, // Slices an input array based on the start and end index
 		"__array_divide":    UDN_ArrayDivide,   //TODO(g): Breaks an array up into a set of arrays, based on a divisor.  Ex: divide=4, a 14 item array will be 4 arrays, of 4/4/4/2 items each.
 		"__array_map_remap": UDN_ArrayMapRemap, //TODO(g): Takes an array of maps, and makes a new array of maps, based on the arg[0] (map) mapping (key_new=key_old)
 


### PR DESCRIPTION
Changes:
- Fixed stack issue with temporary variables; previously temp variable stack for function was not popped
- Cleaned up udn_data temp variable space before popping function temp variable stack (temp variables related to the popped function was cleared for space)
- Removed old UDN_GetIndex function
- Implemented new UDN_GetIndex function (__get_index) that takes input from the input field and allows depth searching
- Implemented UDN_SetIndex function (__set_index) where the input is updated like __set and directly piped to output without storing the input (ex: __input.{key1=value1}.__set_index.key1.(__input.'value2') will yield {key1=value2} as the piped result. Depth is also implemented.
- Modified several function signatures in internals.go from map[string]interface{} to interface{} to allow for more generality and avoid rewriting similar existing functions
- Allow all __get/__set/__get_temp/__set_temp/__get_index/__set_index to work on maps and several types of arrays (before it only worked on maps and []interface{}, now it would work on arrays like []map[string]{}interface)

Tests conducted:
- udn snippets testing __set_index & __get_index via api endpoints to make sure both functions work as intended (~6 sample api tests)
- udn function with udn snippets to test temp variables locality via api endpoints (~5 sample api tests)
- running webpages to test the updated internal function signatures (~15 webpages)