### PR TITLE
Added index out-of-bounds checking for GetChildResult/SetChildResult

### DIFF
--- a/yudien/internals.go
+++ b/yudien/internals.go
@@ -110,15 +110,24 @@ func GetChildResult(parent interface{}, child interface{}) DynamicResult {
 		case []string:
 			parent_array := parent.([]string)
 			index := GetResult(child, type_int).(int64)
-			result.Result = parent_array[index]
+
+			if index >= 0 && index < int64(len(parent_array)) {
+				result.Result = parent_array[index]
+			}
 		case []interface{}:
 			parent_array := parent.([]interface{})
 			index := GetResult(child, type_int).(int64)
-			result.Result = parent_array[index]
+
+			if index >= 0 && index < int64(len(parent_array)) {
+				result.Result = parent_array[index]
+			}
 		case []map[string]interface{}:
 			parent_array := parent.([]map[string]interface{})
 			index := GetResult(child, type_int).(int64)
-			result.Result = parent_array[index]
+
+			if index >= 0 && index < int64(len(parent_array)) {
+				result.Result = parent_array[index]
+			}
 		default:
 			// Array type not recognized - return parent for now
 			result.Result = parent
@@ -190,15 +199,24 @@ func SetChildResult(parent interface{}, child interface{}, value interface{}) {
 		case []string:
 			parent_array := parent.([]string)
 			index := GetResult(child, type_int).(int64)
-			parent_array[index] = value.(string)
+
+			if index >= 0 && index < int64(len(parent_array)) {
+				parent_array[index] = value.(string)
+			}
 		case []interface{}:
 			parent_array := parent.([]interface{})
 			index := GetResult(child, type_int).(int64)
-			parent_array[index] = value
+
+			if index >= 0 && index < int64(len(parent_array)) {
+				parent_array[index] = value
+			}
 		case []map[string]interface{}:
 			parent_array := parent.([]map[string]interface{})
 			index := GetResult(child, type_int).(int64)
-			parent_array[index] = value.(map[string]interface{})
+
+			if index >= 0 && index < int64(len(parent_array)) {
+				parent_array[index] = value.(map[string]interface{})
+			}
 		default:
 			// type is not recognized - do nothing for now
 		}


### PR DESCRIPTION
- Prevents crashing when you go out of bounds on arrays in GetChildResult/SetChildResult.
- You won't crash if you try get.array.1000 and the index is out of bounds, you will get nil back.