### PR TITLE
Perform a deepcopy during child assignment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,6 +45,18 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/mitchellh/copystructure"
+  packages = ["."]
+  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/reflectwalk"
+  packages = ["."]
+  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
+
+[[projects]]
+  branch = "master"
   name = "github.com/nu7hatch/gouuid"
   packages = ["."]
   revision = "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
@@ -100,6 +112,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b3e15ee4330793add3675ad5bf7f78a84d64fc33ac14c8bbe9f0145b9aea89f4"
+  inputs-digest = "8e88d3467096fd505aeb00bebe72f0dde2ef74fe9f1c88da41f1b0b18e556fe0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,3 +32,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/segmentio/ksuid"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/mitchellh/copystructure"

--- a/yudien/internals.go
+++ b/yudien/internals.go
@@ -228,7 +228,7 @@ func SetChildResult(parent interface{}, child interface{}, value interface{}) {
 		parent_map := parent.(map[string]interface{})
 
 		// Set the value
-		parent_map[child_str] = value
+		parent_map[child_str] = DeepCopy(value)
 	}
 }
 

--- a/yudienutil/utility.go
+++ b/yudienutil/utility.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"io/ioutil"
+	"github.com/mitchellh/copystructure"
 )
 
 const (
@@ -618,4 +619,19 @@ func IsStringInArray(text string, arr []string) bool {
 		}
 	}
 	return false
+}
+
+func DeepCopy(v interface{}) interface{} {
+    // copystructure won't take a nil, so early return
+    if v == nil {
+        return nil
+    }
+    // might save a few cycles if we test for unmutable types
+    // and return early?
+    v_copy, err := copystructure.Copy(v)
+    if err != nil {
+        fmt.Print(err)
+        return v
+    }
+    return v_copy
 }


### PR DESCRIPTION
This avoids a number of pitfalls including a stack overflow when a
child links to its parent and unintentional data changes, etc.